### PR TITLE
Updated crd pre-install hook file

### DIFF
--- a/jx-app-cert-manager/templates/pre-install-job.yaml
+++ b/jx-app-cert-manager/templates/pre-install-job.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/name: {{ template "cert-manager.name" . }}
     spec:
-      restartPolicy: {{ .Values.restartPolicy }}
+      restartPolicy: Never
       containers:
       - name: install-crds
         image: "gcr.io/jenkinsxio/builder-go:0.1.437"

--- a/jx-app-cert-manager/templates/pre-install-job.yaml
+++ b/jx-app-cert-manager/templates/pre-install-job.yaml
@@ -20,6 +20,3 @@ spec:
       - name: install-crds
         image: "gcr.io/jenkinsxio/builder-go:0.1.437"
         command: ["kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/{{.Chart.Version}}/deploy/manifests/00-crds.yaml"]
-      - name: set-validation-off
-        image: "gcr.io/jenkinsxio/builder-go:0.1.437"
-        command: ["kubectl label namespace jx certmanager.k8s.io/disable-validation='true'"]

--- a/jx-app-cert-manager/templates/pre-install-job.yaml
+++ b/jx-app-cert-manager/templates/pre-install-job.yaml
@@ -19,4 +19,4 @@ spec:
       containers:
       - name: install-crds
         image: "gcr.io/jenkinsxio/builder-go:0.1.437"
-        command: ["kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/{{.Chart.Version}}/deploy/manifests/00-crds.yaml"]
+        command: ["kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml"]


### PR DESCRIPTION
The following changes have been made:
- Updated the restartPolicy to 'Never'
- Removed the second task which set a label within the namespace as jx applies with validation set to false
- Updated the version with the CRD URL to static value temporarily until we can determine the best way to retrieve it from the cert-manager chart.